### PR TITLE
Don't abort when os.stat fails

### DIFF
--- a/find_unicode_control.py
+++ b/find_unicode_control.py
@@ -131,7 +131,11 @@ def analyze_file(f, disallowed, msg):
 
 # Actual implementation of the recursive descent into directories.
 def analyze_any(p, disallowed, msg, dirs_seen):
-    stat_res = os.stat(p)
+    try:
+        stat_res = os.stat(p)
+    except Exception as e:
+        eprint('%s: %s' % (p, e))
+        return
 
     mode = stat_res.st_mode
     if S_ISDIR(mode):


### PR DESCRIPTION
Currently the script aborts execution if `os.stat()` fails for some
reason, for instance, if it tries to read a symlink that points to an
inexistent file.